### PR TITLE
Fix spelling by renaming hubot_enviroment to hubot_environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A Debian-based system
 | `mattermost_hubot_owner`               | :heavy_check_mark:              | Mail of person that runs this bot                                                                         |
 | `mattermost_hubot_name`                | `James`                         | Name under which the bot should react                                                                     |
 | `mattermost_hubot_description`         | `Your friendly and helpful bot` | Description which the bot should use                                                                      |
-| `mattermost_hubot_enviroment`          | `{}`                            | Dictionary to set more enviroment variables. The key is the variable name and the value the value         |
+| `mattermost_hubot_environment`          | `{}`                            | Dictionary to set more enviroment variables. The key is the variable name and the value the value         |
 | `mattermost_hubot_plugins`             | See below                       | List of plugins to be installed. Name of the package is the same name used in the npm package repository. |
 
 ### `mattermost_hubot_plugins` Default
@@ -54,7 +54,7 @@ Per default following packages are installed:
     mattermost_hubot_mattermost_password: yourpassword
     mattermost_hubot_mattermost_host: url.to.your.mattermost.instance.com
     mattermost_hubot_owner: your@mailaddress.com
-    mattermost_hubot_enviroment:
+    mattermost_hubot_environment:
       - REDIS_URL: redis://:password@192.168.0.1:16379/prefix 
     mattermost_hubot_plugins:
       - hubot-diagnostics

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ mattermost_hubot_log_level: info
 mattermost_hubot_reply: True
 mattermost_hubot_name: James
 mattermost_hubot_description: "Your friendly and heplful bot"
-mattermost_hubot_enviroment: {}
+mattermost_hubot_environment: {}
 mattermost_hubot_plugins:
   - hubot-diagnostics
   - hubot-help

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 # We are using shell and sudo since npm does not respect the user under which a process should run
 - name: Install yo and generator-hubot packages
-  environment: "{{ mattermost_hubot_enviroment_vars }}"
+  environment: "{{ mattermost_hubot_environment_vars }}"
   shell: "npm install {{ item }}"
   changed_when: False
   become_user: "{{ mattermost_hubot_user }}"
@@ -30,7 +30,7 @@
 
 - name: Init hubot
   shell: "sudo -u {{ mattermost_hubot_user }} -E yo hubot --adapter matteruser --owner {{ mattermost_hubot_owner }} --name {{ mattermost_hubot_name }} --description '{{ mattermost_hubot_description }}'"
-  environment: "{{ mattermost_hubot_enviroment_vars }}"
+  environment: "{{ mattermost_hubot_environment_vars }}"
   args:
     chdir: "{{ mattermost_hubot_install_path }}"
     creates: "{{ mattermost_hubot_install_path }}/scripts"
@@ -47,16 +47,16 @@
   notify:
     - Reload systemd daemon
 
-- name: Place enviroment file
+- name: Place environment file
   template:
-    src: hubot_enviroment
+    src: hubot_environment
     dest: /etc/default/hubot
     mode: 0600
     owner: root
     group: root
 
 - name: Install hubot plugins
-  environment: "{{ mattermost_hubot_enviroment_vars }}"
+  environment: "{{ mattermost_hubot_environment_vars }}"
   shell: "npm install {{ item }}"
   become_user: "{{ mattermost_hubot_user }}"
   changed_when: False

--- a/templates/hubot_environment
+++ b/templates/hubot_environment
@@ -14,8 +14,8 @@ MATTERMOST_REPLY={{ mattermost_hubot_reply }}
 MATTERMOST_IGNORE_USERS={{ mattermost_hubot_ignore_users }}
 {% endif %}
 HOME={{ mattermost_hubot_install_path }}
-{% for enviroment_item in mattermost_hubot_enviroment %}
-{% for enviroment_key, enviroment_value in  enviroment_item.items()%}
-{{ enviroment_key }}={{ enviroment_value }}
+{% for environment_item in mattermost_hubot_environment %}
+{% for environment_key, environment_value in  environment_item.items()%}
+{{ environment_key }}={{ environment_value }}
 {% endfor %}
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-mattermost_hubot_enviroment_vars:
+mattermost_hubot_environment_vars:
   HOME: "{{ mattermost_hubot_install_path }}"
   npm_config_user: "{{ mattermost_hubot_user }}"
   npm_config_group: "{{ mattermost_hubot_group }}"


### PR DESCRIPTION
Rename hubot_enviroment to hubot_environment in all files that contain it